### PR TITLE
Upgrade go-gemini-grounded-search to v1.5.0 and switch default to gemini-3.5-flash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Configuration priority: **defaults → config.yml → env vars**
 | Env Var | Config Key | Notes |
 |---------|-----------|-------|
 | `GEMINI_API_KEY` | `gemini.api_key` | Required |
-| `GEMINI_MODEL_NAME` | `gemini.model_name` | Default: `gemini-3.1-pro-preview` |
+| `GEMINI_MODEL_NAME` | `gemini.model_name` | Default: `gemini-3.5-flash` |
 | `GEMINI_MAX_TOKENS` | `gemini.max_tokens` | Default: 5000 |
 | `GEMINI_THINKING_LEVEL` | `gemini.thinking_level` | MINIMAL/LOW/MEDIUM/HIGH (Gemini 3.x series) |
 | `GEMINI_THINKING_BUDGET` | `gemini.thinking_budget` | Token count (Gemini 2.5 series) — fails fast on invalid |

--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,7 @@ http:
 
 gemini:
   api_key: '' # Set via environment variable GEMINI_API_KEY
-  model_name: 'gemini-3.1-pro-preview'
+  model_name: 'gemini-3.5-flash'
   max_tokens: 5000
   thinking_level: 'MEDIUM' # For Gemini 3 series: MINIMAL, LOW, MEDIUM, HIGH
   # thinking_budget: 0  # For Gemini 2.5 series: token count (0 to disable)

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ func defaultValues() map[string]any {
 	return map[string]any{
 		"log":                    "",
 		"debug":                  false,
-		"gemini.model_name":      "gemini-3.1-pro-preview",
+		"gemini.model_name":      "gemini-3.5-flash",
 		"gemini.max_tokens":      5000,
 		"gemini.thinking_level":  "",
 		"http.port":              8080,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cnosuke/mcp-gemini-grounded-search
 go 1.25.0
 
 require (
-	github.com/cnosuke/go-gemini-grounded-search v1.4.0
+	github.com/cnosuke/go-gemini-grounded-search v1.5.0
 	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/confmap v1.0.0
 	github.com/knadh/koanf/providers/file v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cnosuke/go-gemini-grounded-search v1.4.0 h1:2fFHixvqonhLSbo68vX+rvvwSueHYm7BiJwW1Kwe3tY=
-github.com/cnosuke/go-gemini-grounded-search v1.4.0/go.mod h1:NmVT6q++n5bppAzNtqz3bqUUsDh1tAzk+Peg4AFbuYU=
+github.com/cnosuke/go-gemini-grounded-search v1.5.0 h1:2sYcjf+nnPFevHppsl/AtzP/N5gBpW4VvmGZEDEh22M=
+github.com/cnosuke/go-gemini-grounded-search v1.5.0/go.mod h1:NmVT6q++n5bppAzNtqz3bqUUsDh1tAzk+Peg4AFbuYU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=


### PR DESCRIPTION
## Summary

- `github.com/cnosuke/go-gemini-grounded-search` を `v1.4.0` → `v1.5.0` にアップグレード
- デフォルトモデルを `gemini-3.1-pro-preview` → `gemini-3.5-flash` に変更（ライブラリ側のデフォルトに追従）
- `config/config.go`、`config.yml`、`CLAUDE.md` のデフォルト記述を更新

## 背景

go-gemini-grounded-search v1.5.0 でライブラリ側のデフォルトモデルが `gemini-3.5-flash` に変更されたため、本プロジェクトのデフォルトも追従。`thinking_level: MEDIUM` は Gemini 3.x 系の機能なので 3.5 Flash でも有効。API 利用箇所（`searcher/searcher.go`）の互換性は確認済み。

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`（テストファイルなし）
- [x] `go vet ./...`
- [ ] 実 API で `search` ツールが動作することを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)